### PR TITLE
Remove usage of GitRepositoryAsync

### DIFF
--- a/lib/open-git-modified-files.coffee
+++ b/lib/open-git-modified-files.coffee
@@ -15,8 +15,8 @@ module.exports =
 
   open: ->
     for repo in atom.project.getRepositories() when repo?
-      repo.async.getWorkingDirectory().then (workingDirectory) =>
-        for filePath of repo.async.getCachedPathStatuses()
-          filePath = path.join(workingDirectory, filePath)
-          if repo.isPathModified(filePath) or repo.isPathNew(filePath)
-            atom.workspace.open(filePath) if fs.isFileSync(filePath)
+      workingDirectory = repo.getWorkingDirectory()
+      for filePath of repo.statuses
+        filePath = path.join(workingDirectory, filePath)
+        if repo.isPathModified(filePath) or repo.isPathNew(filePath)
+          atom.workspace.open(filePath) if fs.isFileSync(filePath)


### PR DESCRIPTION
GitRepositoryAsync was [removed in 1.9](http://blog.atom.io/2016/08/01/atom-1-9-and-1-10-beta.html). This fixes breakage caused by repo.async not existing.

Fixes #8
